### PR TITLE
Additions to EmailService (configuration fix, configurable display name and method to make secure connection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 out
 target
 .idea
+WebPages
+logs
+data
+server.cfg

--- a/src/main/java/de/bytephil/services/EmailService.java
+++ b/src/main/java/de/bytephil/services/EmailService.java
@@ -3,6 +3,7 @@ package de.bytephil.services;
 import de.bytephil.main.Main;
 import de.bytephil.utils.ServerConfiguration;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 import javax.mail.*;
 import javax.mail.internet.*;
@@ -13,12 +14,17 @@ public class EmailService {
         ServerConfiguration configuration = Main.config;
         //Get properties object
         Properties props = new Properties();
-        props.put("mail.smtp.host", "smtp.gmail.com");
-        props.put("mail.smtp.socketFactory.port", "465");
-        props.put("mail.smtp.socketFactory.class",
-                "javax.net.ssl.SSLSocketFactory");
+        props.put("mail.smtp.host", configuration.emailhost);
+        if (configuration.emailSecureMethod.equalsIgnoreCase("SSL")) {
+            props.put("mail.smtp.socketFactory.port", configuration.emailport);
+            props.put("mail.smtp.socketFactory.class",
+                    "javax.net.ssl.SSLSocketFactory");
+        } else {
+            props.put("mail.smtp.starttls.enable", "true");
+        }
+        props.put("mail.smtp.port", configuration.emailport);
         props.put("mail.smtp.auth", "true");
-        props.put("mail.smtp.port", "465");
+
         //get Session
         Session session = Session.getDefaultInstance(props,
                 new javax.mail.Authenticator() {
@@ -29,12 +35,19 @@ public class EmailService {
         //compose message
         try {
             MimeMessage message = new MimeMessage(session);
-            message.addRecipient(Message.RecipientType.TO,new InternetAddress(to));
+            if (configuration.emailDisplayName.isEmpty()) {
+                message.setFrom(new InternetAddress(configuration.emailuser));
+            } else {
+                message.setFrom(new InternetAddress(configuration.emailuser, configuration.emailDisplayName));
+            }
+            message.setRecipient(Message.RecipientType.TO,new InternetAddress(to));
             message.setSubject(sub);
             message.setText(msg);
             //send message
             Transport.send(message);
-        } catch (MessagingException e) {throw new RuntimeException(e);}
+        } catch (MessagingException e) {throw new RuntimeException(e);} catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
 
     }
     //  EmailService.send(config.emailuser, config.emailpassword, "phitho2018@gmail.com", "Hallo", "Hallo du");

--- a/src/main/java/de/bytephil/utils/Config.java
+++ b/src/main/java/de/bytephil/utils/Config.java
@@ -19,6 +19,8 @@ public class Config {
 
     public String emailhost;
     public int emailport;
+    public String emailSecureMethod;
+    public String emailDisplayName;
     public String emailuser;
     public String emailpassword;
 }

--- a/src/main/java/de/bytephil/utils/ServerConfiguration.java
+++ b/src/main/java/de/bytephil/utils/ServerConfiguration.java
@@ -42,6 +42,8 @@ public class ServerConfiguration extends Config {
         // EMAIL
         emailhost = prop.getProperty("email.smtp.host", "smtp.gmail.com");
         emailport = Integer.parseInt(prop.getProperty("email.smtp.port", "465"));
+        emailSecureMethod = prop.getProperty("email.smtp.secure.method", "STARTTLS");
+        emailDisplayName = prop.getProperty("email.smtp.displayname", "");
         emailuser = prop.getProperty("email.smtp.user", "testuser@gmail.com");
         emailpassword = prop.getProperty("email.smtp.password", "yourPassword");
     }

--- a/src/main/resources/default.cfg
+++ b/src/main/resources/default.cfg
@@ -32,5 +32,9 @@ ssl.keystorePassword=password
 # Email Server Settings
 email.smtp.host=smtp.gmail.com
 email.smtp.port=587
+# Can be STARTTLS or SSL
+email.smtp.secure.method=STARTTLS
+# Name which is shown in place of the email address in most email clients. Leave empty or remove for none
+email.smtp.displayname=
 email.smtp.user=testuser@gmail.com
 email.smtp.password=yourPassword


### PR DESCRIPTION
Hi again,
these changes fix the issue that most of the e-mail configuration values weren't used and add new configuration values for setting the display name (this is shown in the e-mail client aside of the e-mail and looks much better than just an e-mail adress) and the used method for securing the connection to the e-mail server. The method which was always used in the server until now is SSL (a direct connection with SSL/TLS). This is a method which is widely used but not the only on. STARTTLS is the other. They both usually get to the same result, but I think the user should determine which one he likes the best and therefore I added the option (also the port defined in the default config is usually used with STARTTLS).
Best Regards,
Christian